### PR TITLE
tough: add a default transport for http and file

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,3 +25,4 @@ jobs:
     - run: cargo build --locked -p tuftool
     - run: cargo test --locked
     - run: cd tough && cargo test --all-features --locked
+    - run: cd tough && cargo test --features '' --locked

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -50,7 +50,9 @@ use crate::fetch::{fetch_max_size, fetch_sha256};
 pub use crate::http::{ClientSettings, HttpTransport, RetryRead};
 use crate::schema::{DelegatedRole, Delegations};
 use crate::schema::{Role, RoleType, Root, Signed, Snapshot, Timestamp};
-pub use crate::transport::{FilesystemTransport, Transport, TransportError, TransportErrorKind};
+pub use crate::transport::{
+    DefaultTransport, FilesystemTransport, Transport, TransportError, TransportErrorKind,
+};
 use chrono::{DateTime, Utc};
 use snafu::{ensure, OptionExt, ResultExt};
 use std::borrow::Cow;

--- a/tough/tests/transport.rs
+++ b/tough/tests/transport.rs
@@ -1,0 +1,49 @@
+use std::fs;
+use std::str::FromStr;
+use tempfile::TempDir;
+use test_utils::read_to_end;
+use tough::{DefaultTransport, Transport, TransportErrorKind};
+use url::Url;
+
+mod test_utils;
+
+/// If the `http` feature is not enabled, we should get an error message indicating that the feature
+/// is not enabled.
+#[cfg(not(feature = "http"))]
+#[test]
+fn default_transport_error_no_http() {
+    let transport = DefaultTransport::new();
+    let url = Url::from_str("http://example.com").unwrap();
+    let error = transport.fetch(url).err().unwrap();
+    match &error.kind {
+        TransportErrorKind::UnsupportedUrlScheme => {
+            let message = format!("{}", error);
+            assert!(message.contains("http feature"))
+        }
+        _ => panic!("incorrect error kind, expected UnsupportedUrlScheme"),
+    }
+}
+
+#[test]
+fn default_transport_error_ftp() {
+    let transport = DefaultTransport::new();
+    let url = Url::from_str("ftp://example.com").unwrap();
+    let error = transport.fetch(url.clone()).err().unwrap();
+    match &error.kind {
+        TransportErrorKind::UnsupportedUrlScheme => assert_eq!(error.url.as_str(), url.as_str()),
+        _ => panic!("incorrect error kind, expected UnsupportedUrlScheme"),
+    }
+}
+
+#[test]
+fn default_transport_file() {
+    let dir = TempDir::new().unwrap();
+    let filepath = dir.path().join("file.txt");
+    fs::write(&filepath, "123123987").unwrap();
+    let transport = DefaultTransport::new();
+    let url = Url::from_file_path(filepath).unwrap();
+    let read = transport.fetch(url).unwrap();
+    let temp_vec = read_to_end(read);
+    let contents = String::from_utf8_lossy(&temp_vec);
+    assert_eq!(contents, "123123987");
+}


### PR DESCRIPTION
```
Adds a default transport object which supports both file transport and,
if the http feature is enable, HTTP transport. Gives an error message
in the absence of the http feature to help the user understand why http
transport did not work.
```